### PR TITLE
make PluginName mutable

### DIFF
--- a/plugins/gang/const.go
+++ b/plugins/gang/const.go
@@ -2,10 +2,10 @@ package gang
 
 import "github.com/pfnet/scheduler-plugins/plugins/names"
 
-const (
-	// PluginName is the name of the plugin.
-	PluginName = names.Gang
+// PluginName is the name of the plugin.
+var PluginName = names.Gang
 
+const (
 	// GangScheduleTimeoutSecondsDefault is the default value for gang schedule timeout
 	GangScheduleTimeoutSecondsDefault = 30
 


### PR DESCRIPTION
## What this PR does / why we need it:

When the gang plugin allow/reject waiting Pods, it has to tell the plugin name to the scheduler.
But when we use it in [kube-scheduler-simulator](https://github.com/kubernetes-sigs/kube-scheduler-simulator), all plugins' names are replaced with `plugin name + "Wrapped"` so the gang plugin name which the scheduler knows and the gang plugin name which the gang plugin uses to handle waiting Pods would be different and waiting Pods aren't handled correctly.

This PR brings a workaround of rewriting `PluginName` to `PluginName + "Wrapped"` so that the gang plugin name which the scheduler knows and the gang plugin name which the gang plugin uses to handle waiting Pods are the same and waiting Pods are handled correctly.

## Which issue(s) this PR fixes:

Fixes: #
