### PR TITLE
fix gang race condition

### DIFF
--- a/plugins/gang/gangs.go
+++ b/plugins/gang/gangs.go
@@ -351,6 +351,8 @@ func (gangs *Gangs) PreFilter(ctx context.Context, state *framework.CycleState, 
 		state.Write(StateKeyGangFirstPod, gangFirstPod{})
 	}
 
+	gangs.mapLock.RLock()
+	defer gangs.mapLock.RUnlock()
 	return schedulingGang.PreFilter(pod, gangs.timeoutConfig)
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

`gangImpl.pods` is protected by `Gangs.mapLock`. But in `Gangs.PreFilter`, `SchedulingGang.PreFilter` is called without `Gangs.mapLock`. It causes concurrent access to `gangImpl.pods`.

This PR makes sure `SchedulingGang.PreFilter` is called with `Gangs.mapLock`.

## Which issue(s) this PR fixes:

Fixes: #
